### PR TITLE
Missing " at the end of the line for INSTALLED APPS for django_extensions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -34,7 +34,7 @@ hide:
    INSTALLED_APPS = [
        # other Django apps
        "django_tailwind_cli",
-       "django_extensions,
+       "django_extensions",
    ]
    ```
 


### PR DESCRIPTION
Just added a " to the end of the line to ease in copy and pasting from the documentation 