### PR TITLE
Handle prefixed staticfile dir

### DIFF
--- a/src/django_tailwind_cli/config.py
+++ b/src/django_tailwind_cli/config.py
@@ -148,7 +148,12 @@ def get_config() -> Config:
     # Determine the full path to the dist css file
     if not (dist_css_base := getattr(settings, "TAILWIND_CLI_DIST_CSS", "css/tailwind.css")):
         raise ValueError("TAILWIND_CLI_DIST_CSS must not be None.")
-    dist_css = Path(settings.STATICFILES_DIRS[0]) / dist_css_base
+
+    first_staticfile_dir = settings.STATICFILES_DIRS[0]
+    if isinstance(first_staticfile_dir, tuple):
+        # Handle prefixed staticfile dir.
+        first_staticfile_dir = first_staticfile_dir[1]
+    dist_css = Path(first_staticfile_dir) / dist_css_base
 
     # Determine the full path to the source css file.
     src_css = getattr(settings, "TAILWIND_CLI_SRC_CSS", None)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -110,6 +110,24 @@ def test_invalid_settings_for_staticfiles_dirs(settings: SettingsWrapper):
         get_config()
 
 
+def test_string_setting_for_staticfiles_dirs(settings: SettingsWrapper):
+    settings.STATICFILES_DIRS = ["path"]
+    c = get_config()
+    assert c.dist_css == Path("path/css/tailwind.css")
+
+
+def test_path_setting_for_staticfiles_dirs(settings: SettingsWrapper):
+    settings.STATICFILES_DIRS = [Path("path")]
+    c = get_config()
+    assert c.dist_css == Path("path/css/tailwind.css")
+
+
+def test_prefixed_setting_for_staticfiles_dirs(settings: SettingsWrapper):
+    settings.STATICFILES_DIRS = (("prefix", "path"),)
+    c = get_config()
+    assert c.dist_css == Path("path/css/tailwind.css")
+
+
 def test_invalid_settings_for_tailwind_cli_dist_css(settings: SettingsWrapper):
     settings.TAILWIND_CLI_DIST_CSS = None
     with pytest.raises(ValueError, match="TAILWIND_CLI_DIST_CSS must not be None."):


### PR DESCRIPTION
Support prefixed staticfile dir as mentioned in https://docs.djangoproject.com/en/5.2/ref/settings/#prefixes-optional.